### PR TITLE
Only print results distinct from the training set

### DIFF
--- a/markovname/__main__.py
+++ b/markovname/__main__.py
@@ -147,8 +147,16 @@ def main():
             )
         generator = Generator(dataset, order=args.order, prior=args.prior)
         explain(args)
-        for _ in range(args.number):
-            print(generator.generate().strip('#'))
+        i = 0
+        tryagain = 0
+        while i < args.number:
+            result = generator.generate().strip("#")
+            if result not in dataset and tryagain < 3:
+                tryagain += 1
+                continue
+            i += 1
+            tryagain = 0
+            print(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This tool is so fun to play with, thank you to both @bicobus and @Tw1ddle!

I find it nice to filter out results from the training set (just as the Haxe website does). I've only filtered them out of the CLI output, not in the generation itself. If you dislike the change, no worries.