### PR TITLE
bugfix: filtering out training set logic was backwards

### DIFF
--- a/markovname/__main__.py
+++ b/markovname/__main__.py
@@ -154,7 +154,7 @@ def main():
         tryagain = 0
         while i < args.number:
             result = generator.generate().strip("#")
-            if result not in dataset and tryagain < 3:
+            if result in dataset and tryagain < 3:
                 tryagain += 1
                 continue
             i += 1


### PR DESCRIPTION
Fixing a bug in #2 .  When we swapped out the potentially infinite loop for the "three strikes, you're out" one, the filtering logic was backwards.